### PR TITLE
fix(iconsize): make iconSize module-specific b/c DFred Effects

### DIFF
--- a/scripts/Tooltip.js
+++ b/scripts/Tooltip.js
@@ -146,7 +146,7 @@ class Tooltip {
       icon: htmlType ? icon.substring(1) : icon,
       htmlType,
       iconType,
-      iconSize: this._fontSize,
+      ttaIconSize: this._fontSize,
     };
   }
 

--- a/templates/tooltip.hbs
+++ b/templates/tooltip.hbs
@@ -6,7 +6,7 @@
         {{#each stats}}
             <div class="{{../moduleName}}-tooltip-column">
                 {{#each this}}
-                    <div class="{{../../moduleName}}-tooltip-item" style="grid-template-columns: minmax({{iconSize}}rem, 1fr) auto;">
+                    <div class="{{../../moduleName}}-tooltip-item" style="grid-template-columns: minmax({{ttaIconSize}}rem, 1fr) auto;">
                         {{#if htmlType}}
                             <span style="color: {{color}};">{{{icon}}}</span>
                         {{else if iconType}}


### PR DESCRIPTION
# Description

DFred's Effects Panel v4.1.0 registers an `iconSize` [Handlebars helper](https://github.com/DFreds/dfreds-effects-panel/blob/c5d2bd1819e352886a23cf6179b5c63b9b14335a/src/ts/handlebar-helpers.ts#L35-L39) which then collides with a variable used in TTA. This update changes the name of the TTA `iconSize` to `ttaIconSize` to avoid the collision.